### PR TITLE
bitbake: Migrate to new override syntax

### DIFF
--- a/conf/machine/stm32mp1-av96.conf
+++ b/conf/machine/stm32mp1-av96.conf
@@ -149,5 +149,5 @@ ENABLE_CUBEMX_DTB = "1"
 CUBEMX_DTB = "stm32mp157a-av96"
 CUBEMX_PROJECT = "cubemx_project/av96"
 
-DISTRO_FEATURES_append = " virtualization"
+DISTRO_FEATURES:append = " virtualization"
 

--- a/recipes-bsp/av96-root-files/av96-root-files.bb
+++ b/recipes-bsp/av96-root-files/av96-root-files.bb
@@ -43,14 +43,14 @@ do_install() {
     install -m 0644 ${WORKDIR}/lib/systemd/network/53-usb-otg.network ${D}${systemd_unitdir}/network/
 }
 
-FILES_${PN} += "${sysconfdir}"
-FILES_${PN} += "${sysconfdir}/xdg/weston"
-FILES_${PN} += "${sysconfdir}/systemd/network"
-FILES_${PN} += "${sysconfdir}/wpa_supplicant"
-FILES_${PN} += "${base_sbindir}"
-FILES_${PN} += "${bindir}"
-FILES_${PN} += "${datadir}/weston/icon"
-FILES_${PN} += "/home/root"
-FILES_${PN} += "${systemd_unitdir}/network"
+FILES:${PN} += "${sysconfdir}"
+FILES:${PN} += "${sysconfdir}/xdg/weston"
+FILES:${PN} += "${sysconfdir}/systemd/network"
+FILES:${PN} += "${sysconfdir}/wpa_supplicant"
+FILES:${PN} += "${base_sbindir}"
+FILES:${PN} += "${bindir}"
+FILES:${PN} += "${datadir}/weston/icon"
+FILES:${PN} += "/home/root"
+FILES:${PN} += "${systemd_unitdir}/network"
 
-RDEPENDS_${PN} += "bash"
+RDEPENDS:${PN} += "bash"

--- a/recipes-bsp/av96-root-files/base-files_%.bbappend
+++ b/recipes-bsp/av96-root-files/base-files_%.bbappend
@@ -1,4 +1,4 @@
 
-do_install_append () {
+do_install:append () {
     rm ${D}${sysconfdir}/issue
 }

--- a/recipes-bsp/av96-root-files/usbotg-gadget-config.bbappend
+++ b/recipes-bsp/av96-root-files/usbotg-gadget-config.bbappend
@@ -1,5 +1,5 @@
 
-do_install_append () {
+do_install:append () {
     rm -f ${D}${base_sbindir}/stm32_usbotg_eth_config.sh
     rm -f ${D}${systemd_unitdir}/network/53-usb-otg.network
 }

--- a/recipes-bsp/av96-root-files/weston-init.bbappend
+++ b/recipes-bsp/av96-root-files/weston-init.bbappend
@@ -1,4 +1,4 @@
 
-do_install_append () {
+do_install:append () {
     rm -f ${D}${sysconfdir}/xdg/weston/weston.ini
 }

--- a/recipes-bsp/firmware-files/ap1302-firmware.bb
+++ b/recipes-bsp/firmware-files/ap1302-firmware.bb
@@ -11,5 +11,5 @@ do_install() {
     install -m 755 ${WORKDIR}/lib/firmware/ap1302/* ${D}${base_libdir}/firmware/ap1302/
 }
 
-FILES_${PN} += "${base_libdir}/firmware/ap1302"
+FILES:${PN} += "${base_libdir}/firmware/ap1302"
 

--- a/recipes-bsp/firmware-files/wifi-firmware.bb
+++ b/recipes-bsp/firmware-files/wifi-firmware.bb
@@ -13,5 +13,5 @@ do_install() {
     install -m 755 ${WORKDIR}/lib/firmware/brcm/* ${D}${base_libdir}/firmware/brcm/
 }
 
-FILES_${PN} += "${base_libdir}/firmware/brcm"
+FILES:${PN} += "${base_libdir}/firmware/brcm"
 

--- a/recipes-bsp/linux-stm32mp/linux-stm32mp_%.bbappend
+++ b/recipes-bsp/linux-stm32mp/linux-stm32mp_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://0001-linux-ap1302.patch"
 SRC_URI += "file://0002-media-ov5640-reduce-mipi-rate-according-to-maximum-p.patch"

--- a/recipes-bsp/lte-azure-demo/lte-azure-demo.bb
+++ b/recipes-bsp/lte-azure-demo/lte-azure-demo.bb
@@ -14,5 +14,5 @@ do_install() {
     install -m 755 ${WORKDIR}/LTE_sensors_azure_demo/* ${D}/home/root/LTE_sensors_azure_demo
 }
 
-FILES_${PN} += "/home/root"
-RDEPENDS_${PN} = "python3-core bash"
+FILES:${PN} += "/home/root"
+RDEPENDS:${PN} = "python3-core bash"

--- a/recipes-bsp/lte-sensors-dashboard/lte-sensors-dashboard_git.bb
+++ b/recipes-bsp/lte-sensors-dashboard/lte-sensors-dashboard_git.bb
@@ -3,7 +3,7 @@ SECTION = "examples"
 LICENSE = "CLOSED" 
 PR = "r0" 
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 
 SRC_URI = "git://github.com/ArrowElectronics/LTE_sensors_av96_dashboard.git;protocol=https;name=github"
 SRCREV_github = "master"
@@ -19,5 +19,5 @@ do_install() {
     install -m 755 ${WORKDIR}/README-lte-sensors-demo.txt ${D}/home/root/
 }
 
-FILES_${PN} += "/home/root"
+FILES:${PN} += "/home/root"
 

--- a/recipes-bsp/m4projects/m4projects-av96.bb
+++ b/recipes-bsp/m4projects/m4projects-av96.bb
@@ -57,19 +57,19 @@ SRC_URI += "file://Projects/Avenger96/lte_sensors/STM32CubeIDE/CM4/lte_sensors_D
 
 S = "${WORKDIR}/git"
 
-do_compile_prepend() {
+do_compile:prepend() {
     if [ ! -x "${S}/Projects/Avenger96/lte_sensors/SW4STM32" ]; then
         lnr ${S}/Projects/Avenger96/lte_sensors/STM32CubeIDE ${S}/Projects/Avenger96/lte_sensors/SW4STM32
     fi
 }
 
-do_install_append() {
+do_install:append() {
     install -d ${D}/home/root
     lnr ${D}/usr/local/Cube-M4-examples/Avenger96/lte_sensors/fw_cortex_m4.sh ${D}/home/root/fw_cortex_m4.sh
 }
 
-FILES_${PN} += "/home/root"
+FILES:${PN} += "/home/root"
 
 
-SYSTEMD_PACKAGES_remove = " m4projects-stm32mp1 "
-SYSTEMD_SERVICE_${PN} = ""
+SYSTEMD_PACKAGES:remove = " m4projects-stm32mp1 "
+SYSTEMD_SERVICE:${PN} = ""

--- a/recipes-bsp/m4projects/m4projects-stm32mp1.bbappend
+++ b/recipes-bsp/m4projects/m4projects-stm32mp1.bbappend
@@ -4,6 +4,6 @@ M4_BOARDS = " STM32MP157C-DK2 "
 
 # Temporary Add the AI_Character_Recognition firmware ourself.
 # The firmware will be added thanks to meta-st-stm32mp-addons
-PROJECTS_LIST_append_stm32mpcommonmx = " \
+PROJECTS_LIST:append_stm32mpcommonmx = " \
 ${@bb.utils.contains('PROJECTS_LIST_DK2', 'STM32MP157C-DK2/Demonstrations/AI_Character_Recognition', 'STM32MP157C-DK2/Demonstrations/AI_Character_Recognition', '', d)} \
 "

--- a/recipes-bsp/ppp/ppp_%.bbappend
+++ b/recipes-bsp/ppp/ppp_%.bbappend
@@ -1,18 +1,18 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
   
 SRC_URI += "file://etc/ppp/powerkey_ec25.sh"
 SRC_URI += "file://etc/ppp/peers/quectel"
 SRC_URI += "file://etc/ppp/peers/quectel-chat-connect"
 SRC_URI += "file://etc/ppp/peers/quectel-chat-disconnect"
 
-do_configure_append() {
+do_configure:append() {
     sed -i '/ExecStart=.*/a ExecStop=/etc/ppp/powerkey_ec25.sh stop' ${WORKDIR}/ppp@.service
     sed -i '/\[Service\]/a ExecStartPre=/etc/ppp/powerkey_ec25.sh start' ${WORKDIR}/ppp@.service
 }
 
-do_install_append() {
+do_install:append() {
     install -m 755 ${WORKDIR}/etc/ppp/peers/* ${D}${sysconfdir}/ppp/peers/
     install -m 755 ${WORKDIR}/etc/ppp/powerkey_ec25.sh ${D}${sysconfdir}/ppp/
 }
 
-FILES_${PN} += "${sysconfdir}/ppp/peers"
+FILES:${PN} += "${sysconfdir}/ppp/peers"

--- a/recipes-bsp/python3-libs/python3-requests-unixsocket_0.2.0.bb
+++ b/recipes-bsp/python3-libs/python3-requests-unixsocket_0.2.0.bb
@@ -9,6 +9,6 @@ SRC_URI[sha256sum] = "9e5c1a20afc3cf786197ae59c79bcdb0e7565f218f27df5f891307ee88
 inherit pypi setuptools3
 
 DEPENDS += "python3-pbr-native"
-RDEPENDS_${PN} = "python3-requests python3-urllib3"
+RDEPENDS:${PN} = "python3-requests python3-urllib3"
 
 BBCLASSEXTEND = "native"

--- a/recipes-bsp/sdcard-raw-tools/sdcard-raw-tools.bbappend
+++ b/recipes-bsp/sdcard-raw-tools/sdcard-raw-tools.bbappend
@@ -1,5 +1,5 @@
 
-do_configure_append() {
+do_configure:append() {
     if [ -e ${WORKDIR}/create_sdcard_from_flashlayout.sh ]; then
         bbnote "Update DEFAULT_ROOTFS_PARTITION_SIZE to ${ROOTFS_PARTITION_SIZE}"
         sed 's/^DEFAULT_ROOTFS_PARTITION_SIZE=.*$/DEFAULT_ROOTFS_PARTITION_SIZE='"${ROOTFS_PARTITION_SIZE}"'/' -i ${WORKDIR}/create_sdcard_from_flashlayout.sh

--- a/recipes-bsp/u-boot/u-boot-stm32mp_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-stm32mp_%.bbappend
@@ -1,3 +1,3 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://0001-u-boot-av96-drivers.patch"


### PR DESCRIPTION
It's compatible with dunfell and will be need for kirkstone
(branch to be created once merged)

Forwarded: https://github.com/dh-electronics/meta-av96/pulls?q=author%3Arzr
Signed-off-by: Philippe Coval <philippe.coval@astrolabe.coop>